### PR TITLE
GPII-601: Corrected universal dependency 

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "bugs": "http://wiki.gpii.net/index.php/Main_Page",
     "homepage": "http://gpii.net/",
     "dependencies": {
-        "universal": "git://github.com/yzen/universal.git"
+        "universal": "git://github.com/GPII/universal.git"
     },
     "licenses": [
         {


### PR DESCRIPTION
Corrected the dependency for the Unversal repo to point at GPII/universal instead of yzen/universal.

http://issues.gpii.net/browse/GPII-601
