### PR TITLE
GPII-648: Reflect system level changes in page when saving preferences.

### DIFF
--- a/src/pmt/js/PMTFrame.js
+++ b/src/pmt/js/PMTFrame.js
@@ -69,6 +69,11 @@ https://github.com/GPII/prefsEditors/LICENSE.txt
                 "onLogin.showUserStatusBar": {
                     "listener": "{that}.showUserStatusBar"
                 },
+                // reload location onLogin so that page takes any system-level changes, e.g. new contrast theme
+                "onLogin.reloadLocation": {
+                    "this": "location",
+                    "method": "reload"
+                },
                 // set href of quick editor link when we log the user in
                 "onLogin.setQuickEditorLinkHref": {
                     "listener": "{that}.setQuickEditorLinkHref"
@@ -97,6 +102,11 @@ https://github.com/GPII/prefsEditors/LICENSE.txt
                 },
                 "onLogout.gpiiLogout": {
                     listener: "{gpiiSession}.logout"
+                },
+                // reload location onLogout so that page takes any system-level changes, e.g. reverting contrast theme
+                "onLogout.reloadLocation": {
+                    "this": "location",
+                    "method": "reload"
                 },
                 // set texts
                 "onReady.setMyPreferencesLabelText": {

--- a/src/shared/common/GpiiStore.js
+++ b/src/shared/common/GpiiStore.js
@@ -150,6 +150,9 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
              * Preference management tools should not have session management responsibilities.
              * This is a work-around for the pilot2 tests.
              * */
+            
+            // reload page after AT refresh so that it takes any system-level changes, e.g. new contrast theme
+            location.reload();
         }
         fluid.log("POST: Saved to GPII server");
     };


### PR DESCRIPTION
Link to JIRA: http://issues.gpii.net/browse/GPII-648

This pull request tries to reflect changes in high contrast settings immediately in PMT, when user saves preferences.
In the architecture side, enabling highContrast will set the system-level theme. Modern browsers detect this and override any CSS defined with theme-specific styling. The problem is that when PMT changes highContrast and saves, there is no way of responding to that system-level change from within the page. From one perspective, one might argue that browsers should auto-detect this and override CSS instantly. This is not the case unfortunately (at least in Windows 7, FF that i've tested). I was also hoping the invkoking Fluid's refreshView() on panels would achieve this, but again this was not the case also.
Only way to achieve this was by reloading the whole page. Had to location.reload() onLogin, onLogout and after the AT applications refresh. Solution seems a bit awkward and degrades Ux and repsonsiveness with all those reloads but couldn't find something better and my 1d estimate for this JIRA run out!

A solution to this would be to tell browsers NOT to use system-level theme (FF has this, don't know of other browsers) and have control of in-page styling with enactors, like we did in the past...
