### PR TITLE
GPII-724: Fixed problem with on/off switches always being reported as unselected from NVDA.

### DIFF
--- a/src/shared/adjusters/js/onOffSwitch.js
+++ b/src/shared/adjusters/js/onOffSwitch.js
@@ -91,7 +91,7 @@ https://github.com/GPII/prefsEditors/LICENSE.txt
     gpii.adjuster.onOffSwitch.init = function (that, onOffModelKey) {
         that.applier.modelChanged.addListener(onOffModelKey, function (newModel) {
             var onOffSwitch = that.locate("onOffSwitch");
-            onOffSwitch.attr("aria-pressed", newModel[onOffModelKey]);
+            onOffSwitch.attr("aria-checked", newModel[onOffModelKey]);
         });
     };
 
@@ -99,9 +99,9 @@ https://github.com/GPII/prefsEditors/LICENSE.txt
         that.container.attr("role", "application");
 
         var onOffSwitch = that.locate("onOffSwitch");
-        onOffSwitch.attr("role", "button");
+        onOffSwitch.attr("role", "checkbox");
         onOffSwitch.attr("aria-labelledby", gpii.ariaUtility.getLabelId(that.locate("headingLabel")));
-        onOffSwitch.attr("aria-pressed", that.model[that.options.onOffModelKey]);
+        onOffSwitch.attr("aria-checked", that.model[that.options.onOffModelKey]);
     };
 
 })(jQuery, fluid);


### PR DESCRIPTION
Link to JIRA: http://issues.gpii.net/browse/GPII-724

The screen reader now reads,
"Speak text checkbox not checked"
when the on/off toggle is off and,
"Speak text checkbox checked"
when the toggle is on.
Note that this change has been applied to all on/off switches since this is happening in the reused grade "gpii.adjuster.onOffSwitch".
