### PR TITLE
GPII-727: Made closing token creation dialog accessible.

### DIFF
--- a/src/pmt/js/PMTFrame.js
+++ b/src/pmt/js/PMTFrame.js
@@ -139,6 +139,11 @@ https://github.com/GPII/prefsEditors/LICENSE.txt
                     "method": "text",
                     "args": ["{that}.stringBundle.notificationConfirmButton"]
                 },
+                "onReady.setNotificationConfirmButtonAriaLabel": {
+                    "this": "{that}.dom.notificationConfirmButton",
+                    "method": "attr",
+                    "args": ["aria-label", "{that}.stringBundle.notificationAriaLabel"]
+                },
                 "onReady.setLogoutLinkText": {
                     "this": "{that}.dom.logoutLink",
                     "method": "text",
@@ -259,6 +264,18 @@ https://github.com/GPII/prefsEditors/LICENSE.txt
             closeOnEscape: false,
             position: { my: "bottom", at: "bottom", of: ".gpii-prefsEditor-preferencesContainer" }
         });
+        
+        /*
+         * FIXME: Dirty fix for triggering the "got it" click with the enter key.
+         * jQuery UI Dialog seems to be lacking certain accessibility features.
+         * This is needed for users that use the screen reader to navigate through the tool.
+         */
+        $('body').on('keypress', '.ui-dialog', function(event) {
+            if (event.keyCode === $.ui.keyCode.ENTER) {
+                that.dom.locate("confirmButton").click();
+            }
+        });
+        
         // also set the token text
         that.dom.locate("notificationMessagePart2").text(userToken);
     };

--- a/src/shared/frames/messages/de/frames.json
+++ b/src/shared/frames/messages/de/frames.json
@@ -9,6 +9,7 @@
     "notificationMessagePart3": "auf USB oder RFID-Lesegerät.",
     "notificationTitle": "Bevorzugte Einstellungen wurden in der Cloud gespeichert und auf diesem Gerät angewendet.",
     "notificationConfirmButton": "verstanden",
+    "notificationAriaLabel": "Press Enter to close this dialog",
     "fullEditorText": "Alle Einstellungen",
     "quickEditorText": "Einfache Einstellungen",
     "logoutText": "ausloggen",

--- a/src/shared/frames/messages/el/frames.json
+++ b/src/shared/frames/messages/el/frames.json
@@ -9,6 +9,7 @@
     "notificationMessagePart3": "σέ ένα USB ή RFID.",
     "notificationTitle": "Οι προτιμήσεις αποθηκεύτηκαν στο σύννεφο και εφαρμόστηκαν σε αυτή τη συσκευή.",
     "notificationConfirmButton": "το κατάλαβα",
+    "notificationAriaLabel": "Press Enter to close this dialog",
     "fullEditorText": "πλήρης διαχείριση",
     "quickEditorText": "γρήγορη διαχείριση",
     "logoutText": "εξοδος",

--- a/src/shared/frames/messages/en/frames.json
+++ b/src/shared/frames/messages/en/frames.json
@@ -9,6 +9,7 @@
     "notificationMessagePart3": "to a USB or RFID reader.",
     "notificationTitle": "Preferences have been saved to the cloud and applied to this device.",
     "notificationConfirmButton": "got it",
+    "notificationAriaLabel": "Press Enter to close this dialog",
     "fullEditorText": "full editor",
     "quickEditorText": "quick editor",
     "logoutText": "log-out",

--- a/src/shared/frames/messages/es/frames.json
+++ b/src/shared/frames/messages/es/frames.json
@@ -9,6 +9,7 @@
     "notificationMessagePart3": "a una memoria USB o una etiqueta RFID.",
     "notificationTitle": "Tus preferencias se han guardado en la nube  y se han aplicado en este dispositivo.",
     "notificationConfirmButton": "aceptar",
+    "notificationAriaLabel": "Press Enter to close this dialog",
     "fullEditorText": "editor completo",
     "quickEditorText": "editor rápido",
     "logoutText": "salir",


### PR DESCRIPTION
Link to JIRA: http://issues.gpii.net/browse/GPII-727

Well, it looks like the jQuery UI dialog lacks certain accessibility features. Specifically, it does not seem to honour tabIndex attributes and key navigation techniques. A google search with "jquery ui dialog tabindex" will give some clues on these issues. The bottom line is that there was no direct way of letting the "got it" button take the focus and at the same time allowing the screen reader to read the dialog contents.
So, in order to overcome this i did the following:
1) Set a descriptive aria-label to the "got it" button for the screen reader to read.
2) Catching the Enter key on dialog to trigger a click on "got it".
This way the screen reader will read "Press Enter to close this dialog" at the end of the dialog text and hitting Enter will close the dialog as if "got it" was pressed.

Will need some feedback from the Ux team about this proposed solution. Once this workaround is accepted, i'll request translations for the texts.
