### PR TITLE
GPII-695: Punctuation marks' box becomes unusable after applying changes on the PMT

### DIFF
--- a/src/shared/adjusters/js/Panels.js
+++ b/src/shared/adjusters/js/Panels.js
@@ -370,7 +370,8 @@ https://github.com/GPII/prefsEditors/LICENSE.txt
                     "{that}.dom.punctuationVerbosityContainer",
                     "{that}.dom.punctuationVerbosityLabel",
                     "{that}.dom.announceLabel"
-                ]
+                ],
+                "dynamic": true
             }
         }
     });


### PR DESCRIPTION
Link to JIRA: http://issues.gpii.net/browse/GPII-695
