### PR TITLE
GPII-729: Remove "role=application" attribute from onOffSwitch adjuster.

### DIFF
--- a/src/shared/adjusters/js/onOffSwitch.js
+++ b/src/shared/adjusters/js/onOffSwitch.js
@@ -96,8 +96,6 @@ https://github.com/GPII/prefsEditors/LICENSE.txt
     };
 
     gpii.adjuster.onOffSwitch.addAria = function (that) {
-        that.container.attr("role", "application");
-
         var onOffSwitch = that.locate("onOffSwitch");
         onOffSwitch.attr("role", "checkbox");
         onOffSwitch.attr("aria-labelledby", gpii.ariaUtility.getLabelId(that.locate("headingLabel")));


### PR DESCRIPTION
http://issues.gpii.net/browse/GPII-729
