### PR TITLE
URLs for bugs, homepage and repository

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
     "description": "Editors, responsible for authoring user preference sets.",
     "version": "0.1.0",
     "author": "GPII",
-    "bugs": "http://wiki.gpii.net/index.php/Main_Page",
-    "homepage": "http://gpii.net/",
+    "bugs": "http://issues.gpii.net/browse/GPII/component/10205",
+    "homepage": "http://wiki.gpii.net/w/User_Preferences_UX",
     "dependencies": {
         "kettle": "git://github.com/fluid-project/kettle.git#2cd608b95a7e908769c91f5120cfc50bfc19c4db"
     },
@@ -24,7 +24,7 @@
         "configuration",
         "evented"
     ],
-    "repository": "git://github.com:GPII/prefsEditors.git",
+    "repository": "git://github.com/GPII/prefsEditors.git",
     "engines": {
         "node": ">=0.1.9"
     },


### PR DESCRIPTION
Just nitpicking ;-)
* The URL for the repository was broken due to a typo. 
* The URL for bugs didn't point to JIRA.
* The URL for the homepage pointed to the GPII homepage; the User Preferences UX page (or perhaps http://wiki.gpii.net/w/Preferences_Framework_Overview) would be more informative.